### PR TITLE
Update URL to be compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please note that is docset is not very optimal because the `dashing.json` is not
 Open `Preferences` of the Dash menu, then navigate to the `Downloads` tab. After that, click the + button at the bottom of the window. Add this URL for 'Docset Feed URL':
 
 ```
-https://raw.githubusercontent.com/imWildCat/flutter-docset/master/flutter.xml
+https://cdn.jsdelivr.net/gh/imWildCat/flutter-docset@master/flutter.xml
 ```
 
 Finally, click the 'Download' button of the newly added `flutter` docset.


### PR DESCRIPTION
Due limitation in raw.githubuserocontent file is not read by dash as a valid docset url instead use a CDN (jsDelivr) that point to the file with right Headers.